### PR TITLE
Update breakout_ddqn.py

### DIFF
--- a/3-atari/1-breakout/breakout_ddqn.py
+++ b/3-atari/1-breakout/breakout_ddqn.py
@@ -131,7 +131,7 @@ class DDQNAgent:
             reward.append(mini_batch[i][2])
             dead.append(mini_batch[i][4])
 
-        value = self.model.predict(history)
+        value = self.model.predict(next_history)
         target_value = self.target_model.predict(next_history)
 
         # like Q Learning, get maximum Q value at s'


### PR DESCRIPTION
In the article, I know that both value and target_value use next_history.

Reference : https://arxiv.org/pdf/1509.06461.pdf