### PR TITLE
Use loop break instead of sys.exit() on early stop

### DIFF
--- a/2-cartpole/1-dqn.py
+++ b/2-cartpole/1-dqn.py
@@ -18,7 +18,6 @@ Loss (per minibatch sample):
     L(theta) = ( Q_theta(s)[a] - y )^2
 """
 import random
-import sys
 from collections import deque
 
 import numpy as np
@@ -135,8 +134,11 @@ if __name__ == "__main__":
         run_test_loop(env, agent.get_action)
 
     scores = []
+    solved = False
 
     for e in range(EPISODES):
+        if solved:
+            break
         done = False
         score = 0
         state, _ = env.reset()
@@ -168,9 +170,8 @@ if __name__ == "__main__":
 
                 # Early stop when consistently near max episode length.
                 if np.mean(scores[-min(10, len(scores)):]) > 490:
-                    torch.save(agent.model.state_dict(), SAVE_PATH)
-                    print(f"Saved trained model to {SAVE_PATH}")
-                    sys.exit()
+                    solved = True
+                    break
 
     torch.save(agent.model.state_dict(), SAVE_PATH)
     print(f"Saved trained model to {SAVE_PATH}")

--- a/2-cartpole/2-a2c.py
+++ b/2-cartpole/2-a2c.py
@@ -19,7 +19,6 @@ Updates (one-step, online — like a TD(0) actor-critic):
 Subtracting V_w(s) is the variance-reduction baseline; using a learned V
 (rather than the Monte-Carlo return) is what makes this *actor-critic*.
 """
-import sys
 
 import numpy as np
 import torch
@@ -125,8 +124,11 @@ if __name__ == "__main__":
         run_test_loop(env, agent.get_action)
 
     scores = []
+    solved = False
 
     for e in range(EPISODES):
+        if solved:
+            break
         done = False
         score = 0
         state, _ = env.reset()
@@ -149,10 +151,8 @@ if __name__ == "__main__":
                 scores.append(score)
                 print(f"episode: {e}  score: {score}")
                 if np.mean(scores[-min(10, len(scores)):]) > 490:
-                    torch.save({"actor": agent.actor.state_dict(),
-                                "critic": agent.critic.state_dict()}, SAVE_PATH)
-                    print(f"Saved trained model to {SAVE_PATH}")
-                    sys.exit()
+                    solved = True
+                    break
 
     torch.save({"actor": agent.actor.state_dict(),
                 "critic": agent.critic.state_dict()}, SAVE_PATH)

--- a/2-cartpole/3-ppo.py
+++ b/2-cartpole/3-ppo.py
@@ -27,7 +27,6 @@ Total loss combines clipped policy loss, value MSE, and an entropy bonus:
 
     L = L^CLIP - c_v * MSE(V, returns) + c_e * H[pi]
 """
-import sys
 
 import numpy as np
 import torch
@@ -211,9 +210,7 @@ if __name__ == "__main__":
             recent = ep_returns[-10:]
             print(f"update: {episode}  recent_mean_return: {np.mean(recent):.1f}  episodes: {len(ep_returns)}")
             if len(recent) >= 10 and np.mean(recent) > 490:
-                torch.save(model.state_dict(), SAVE_PATH)
-                print(f"Saved trained model to {SAVE_PATH}")
-                sys.exit()
+                break
 
     torch.save(model.state_dict(), SAVE_PATH)
     print(f"Saved trained model to {SAVE_PATH}")


### PR DESCRIPTION
## Summary
- Replace `sys.exit()` in the three CartPole training scripts with a clean loop exit so the function returns normally instead of tearing down the process.
- DQN/A2C use a `solved` flag (nested while/for); PPO has a single outer loop so a plain `break` is enough.
- The final `torch.save` now runs through one code path whether training ends from early stop or from exhausting `EPISODES`.

## Why
`sys.exit()` raises `SystemExit`, which:
- Skips `env.close()` and any outer cleanup
- Makes the training function impossible to import/unit-test (the test process dies too)
- Kills the kernel under Jupyter/IPython

Credit to @AlexisBogroff in #84 for flagging the pattern on the original TF code; this PR applies the same idea to the current PyTorch tree.

## Test plan
- [ ] `python 2-cartpole/1-dqn.py` — confirm it stops cleanly when the 10-episode running mean crosses 490 and the saved model loads via `--test`
- [ ] Same for `2-cartpole/2-a2c.py` and `2-cartpole/3-ppo.py`