### PR TITLE
Add FireResetEnv and enable terminal_on_life_loss for Atari

### DIFF
--- a/3-atari/env.py
+++ b/3-atari/env.py
@@ -17,6 +17,18 @@ import torch
 
 gym.register_envs(ale_py)
 
+
+# Breakout (and a few other games) require pressing FIRE to launch the ball
+# after each reset / life loss. AtariPreprocessing only does NOOPs, so without
+# this the agent wastes a lot of frames waiting for a random FIRE.
+class FireResetEnv(gym.Wrapper):
+    def reset(self, **kwargs):
+        self.env.reset(**kwargs)
+        obs, _, terminated, truncated, _ = self.env.step(1)  # FIRE
+        if terminated or truncated:
+            obs, _ = self.env.reset(**kwargs)
+        return obs, {}
+
 ENV_IDS = {
     "breakout": "ALE/Breakout-v5",
     "pong":     "ALE/Pong-v5",
@@ -47,10 +59,12 @@ def make_env(args):
         noop_max=30,
         frame_skip=4,
         screen_size=84,
-        terminal_on_life_loss=False,
+        terminal_on_life_loss=True,
         grayscale_obs=True,
         scale_obs=False,        # keep uint8; we normalize in the model
     )
+    if "FIRE" in env.unwrapped.get_action_meanings():
+        env = FireResetEnv(env)
     env = gym.wrappers.FrameStackObservation(env, stack_size=4)
     return env
 


### PR DESCRIPTION
## Summary
- Add `FireResetEnv` wrapper that presses FIRE on reset for games that need it (Breakout). Pong unaffected since FIRE isn't in its action set.
- Flip `terminal_on_life_loss` to `True` to match the Nature DQN / CleanRL convention.

## Why
PPO on Breakout was plateauing around ~14 mean return at ~870k frames. Two standard pieces of the Atari preprocessing stack were missing:
- Without FIRE-on-reset, the agent burns frames every episode waiting to randomly press FIRE before the ball even launches.
- With life-loss not terminating the episode, the credit for a death-causing action is diluted across hundreds of steps and 4 surviving lives.

Both DQN and PPO share `3-atari/env.py`, so both benefit.

## Note
Reported `recent_mean_return` on Breakout will look ~5x smaller now since it reflects per-life score instead of full-game (5-life) score. The thing to watch is the slope, not the absolute number.

## Test plan
- [ ] Re-run `python 3-atari/2-ppo.py --env breakout` and confirm return climbs faster than the prior baseline
- [ ] Sanity check `python 3-atari/2-ppo.py --env pong` still runs (FireResetEnv should be skipped)
- [ ] Sanity check `python 3-atari/1-dqn.py --env breakout` still runs